### PR TITLE
Fix crash in Powder Mixer

### DIFF
--- a/src/main/java/com/globbypotato/rockhounding_chemistry/machines/tile/TEPowderMixerController.java
+++ b/src/main/java/com/globbypotato/rockhounding_chemistry/machines/tile/TEPowderMixerController.java
@@ -252,28 +252,32 @@ public class TEPowderMixerController extends TileEntityInv implements IInternalS
 		TEMaterialCabinetBase materialCabinet = getMaterialCabinet();
 
 		// This shouldn't happen, but it just check to be safe
-		if (currentRecipe == null || elementsCabinet == null || materialCabinet == null)
+		if (currentRecipe == null)
 			return false;
 	
 		outer: for(int i = 0; i < currentRecipe.getElements().size(); i++) {
 			String recipeIngredient = currentRecipe.getElements().get(i);
 			int recipeQuantity = currentRecipe.getQuantities().get(i);
 
-			for (ElementsCabinetRecipe element : elementsCabinet.MATERIAL_LIST) {
-				if (element.getOredict().matches(recipeIngredient) && element.getAmount() >= recipeQuantity) {
-					// Valid match
-					continue outer;
+			if (elementsCabinet != null) {
+				for (ElementsCabinetRecipe element : elementsCabinet.MATERIAL_LIST) {
+					if (element.getOredict().matches(recipeIngredient) && element.getAmount() >= recipeQuantity) {
+						// Valid match
+						continue outer;
+					}
 				}
 			}
 
-			for (MaterialCabinetRecipe material : materialCabinet.MATERIAL_LIST) {
-				if (material.getOredict().matches(recipeIngredient) && material.getAmount() >= recipeQuantity) {
-					// Valid match
-					continue outer;
+			if (materialCabinet != null) {
+				for (MaterialCabinetRecipe material : materialCabinet.MATERIAL_LIST) {
+					if (material.getOredict().matches(recipeIngredient) && material.getAmount() >= recipeQuantity) {
+						// Valid match
+						continue outer;
+					}
 				}
 			}
 
-			// No matches
+			// Ingredient wasn't matched
 			return false;
 		}
 

--- a/src/main/java/com/globbypotato/rockhounding_chemistry/machines/tile/TEPowderMixerController.java
+++ b/src/main/java/com/globbypotato/rockhounding_chemistry/machines/tile/TEPowderMixerController.java
@@ -235,6 +235,7 @@ public class TEPowderMixerController extends TileEntityInv implements IInternalS
 
 	private boolean canProcess() {
 		return isActive()
+			&& isAssembled()
 			&& isValidRecipe()
 			&& isFullRecipe()
 			&& hasRedstonePower()
@@ -242,35 +243,42 @@ public class TEPowderMixerController extends TileEntityInv implements IInternalS
 			&& handleServer(getServer(), this.currentFile);
 	}
 
+	/**
+	 * Check if the current recipe's requirements can be satisfied
+	 */
 	private boolean isFullRecipe() {
-		int recipeTotal = getCurrentRecipe().getElements().size();
-		int countedIngr = 0;
+		PowderMixerRecipe currentRecipe = getCurrentRecipe();
+		TEElementsCabinetBase elementsCabinet = getElementsCabinet();
+		TEMaterialCabinetBase materialCabinet = getMaterialCabinet();
+
+		// This shouldn't happen, but it just check to be safe
+		if (currentRecipe == null || elementsCabinet == null || materialCabinet == null)
+			return false;
 	
-		for(int i = 0;  i < recipeTotal; i++){
-			String recipeIngredient = getRecipeList(getSelectedRecipe()).getElements().get(i);
-			int recipeQuantity = getCurrentRecipe().getQuantities().get(i);
+		outer: for(int i = 0; i < currentRecipe.getElements().size(); i++) {
+			String recipeIngredient = currentRecipe.getElements().get(i);
+			int recipeQuantity = currentRecipe.getQuantities().get(i);
 
-			for(int j = 0; j < getElementsCabinet().MATERIAL_LIST.size(); j++) {
-				String cabinetIngredient = getElementsCabinet().MATERIAL_LIST.get(j).getOredict();
-				if(cabinetIngredient.matches(recipeIngredient)){
-					int cabinetQuantity = getElementsCabinet().MATERIAL_LIST.get(j).getAmount();
-					if(cabinetQuantity >= recipeQuantity) {
-						countedIngr++;
-					}
+			for (ElementsCabinetRecipe element : elementsCabinet.MATERIAL_LIST) {
+				if (element.getOredict().matches(recipeIngredient) && element.getAmount() >= recipeQuantity) {
+					// Valid match
+					continue outer;
 				}
 			}
 
-			for(int j = 0; j < getMaterialCabinet().MATERIAL_LIST.size(); j++) {
-				String cabinetIngredient = getMaterialCabinet().MATERIAL_LIST.get(j).getOredict();
-				if(cabinetIngredient.matches(recipeIngredient)){
-					int cabinetQuantity = getMaterialCabinet().MATERIAL_LIST.get(j).getAmount();
-					if(cabinetQuantity >= recipeQuantity) {
-						countedIngr++;
-					}
+			for (MaterialCabinetRecipe material : materialCabinet.MATERIAL_LIST) {
+				if (material.getOredict().matches(recipeIngredient) && material.getAmount() >= recipeQuantity) {
+					// Valid match
+					continue outer;
 				}
 			}
+
+			// No matches
+			return false;
 		}
-		return countedIngr == recipeTotal;
+
+		// All ingredients were found
+		return true;
 	}
 
 	private boolean canOutput() {


### PR DESCRIPTION
I assembled a powder mixer and got a crash as soon as I activated it that killed my world (stack trace below). Looks like there's a NPE in `isFullRecipe()` when the material/element cabinets aren't present.

Also made a minor change to `isFullRecipe()` so it doesn't keep checking 

I'm not sure, but there might be another bug or two:
- In `isAssembled()` it requires both a material and elements cabinet to work (even for recipes which only use one or the other).
- In `isFullRecipe()` the recipe ingredients are compared with `String.matches()` which more CPU-expensive than `String.equals()` / `String.equalsIgnoreCase()`. Are the recipes supposed to be regexes?

Stack trace:
```
java.lang.NullPointerException
    at com.globbypotato.rockhounding_chemistry.machines.tile.TEPowderMixerController.isFullRecipe(TEPowderMixerController.java:253)
    at com.globbypotato.rockhounding_chemistry.machines.tile.TEPowderMixerController.canProcess(TEPowderMixerController.java:239)
    at com.globbypotato.rockhounding_chemistry.machines.tile.TEPowderMixerController.TickCentral_TrueITickableUpdate(TEPowderMixerController.java:207)
    at com.github.terminatornl.tickcentral.api.TickHub.trueUpdate(TickHub.java:48)
    at com.github.terminatornl.laggoggles.Main.redirectUpdate(Main.java:94)
    at com.globbypotato.rockhounding_chemistry.machines.tile.TEPowderMixerController.update(TEPowderMixerController.java)
    at com.zeitheron.hammercore.asm.McHooks.tickTile(McHooks.java:38)
    at net.minecraft.world.World.updateEntities(World.java:1838)
    at net.minecraft.world.WorldServer.updateEntities(WorldServer.java:613)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:767)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668)
    at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:185)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Unknown Source)
```